### PR TITLE
exec redis in entrypoint.sh

### DIFF
--- a/etc/scripts/entrypoint.sh
+++ b/etc/scripts/entrypoint.sh
@@ -26,7 +26,7 @@ if [ -z "${REDISGRAPH_ARGS}" ]; then
 REDISGRAPH_ARGS="MAX_QUEUED_QUERIES 25 TIMEOUT 1000 RESULTSET_SIZE 10000"
 fi
 
-${CMD} \
+exec ${CMD} \
 ${CONFFILE} \
 --dir ${REDIS_DATA_DIR} \
 --protected-mode no \


### PR DESCRIPTION
Currently entrypoint.sh just starts redis.
The process chain is `dumb-init -> /bin/sh -> redis`.
When the docker container is stopped, dumb-init receives SIGTERM and forwards it to all processes. /bin/sh exits directly without waiting for redis. Because /bin/sh is the direct child of dumb-init, this causes dumb-init to stop and the docker container is stopped.

Thus redis doesn't have a chance to save its content to disk.

This PR starts redis with exec in entrypoint.sh. This replaces the /bin/sh process with redis, so the process chain is `dumb-init -> redis`.
Now redis is the direct child of dumb-init, so dumb-init waits for redis to exit. redis can dump its content to disk and only then the container is stopped (unless the docker stop timeout has elapsed).

